### PR TITLE
Only return one root element from PropTypesPanel

### DIFF
--- a/src/PropTypesPanel.js
+++ b/src/PropTypesPanel.js
@@ -38,12 +38,16 @@ export default class PropTypesPanel extends React.Component {
       return <EmptyState />;
     }
 
-    return types.map((type, i) => (
-      <PropTypesTable
-        key={i}
-        name={type.displayName}
-        propDefinitions={_.values(type.props)}
-      />
-    ));
+    return (
+      <div>
+        {types.map((type, i) => (
+          <PropTypesTable
+            key={i}
+            name={type.displayName}
+            propDefinitions={_.values(type.props)}
+          />
+        ))}
+      </div>
+    );
   }
 }


### PR DESCRIPTION
This PR fixes an issue where if a story is showing multiple tables for multiple components, the first table is set to position absolutely by Storybook.

**Screenshot of issue:**

![Screenshot 2019-09-18 at 13 57 09](https://user-images.githubusercontent.com/4446634/65146518-4ef30680-da1c-11e9-8939-b33d37b538bb.png)
